### PR TITLE
[FEATURE] Redis 키와 값 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ replay_pid*
 
 # Environment variables
 *.env
-application.properties
+src/main/resources/application.properties
 
 ### build
 target/

--- a/src/main/java/fitloop/member/controller/ReissueController.java
+++ b/src/main/java/fitloop/member/controller/ReissueController.java
@@ -78,7 +78,8 @@ public class ReissueController {
         String newRefresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
 
         // AccessToken Redis에 저장 (10분 TTL)
-        redisTemplate.opsForValue().set("ACCESS:" + newAccess, username, 10, TimeUnit.MINUTES);
+        String redisKey = "auth:access:" + newAccess;
+        redisTemplate.opsForValue().set(redisKey, username, 10, TimeUnit.MINUTES);
 
         // 기존 Refresh 삭제, 새로 저장
         refreshRepository.deleteByRefresh(refresh);

--- a/src/main/java/fitloop/member/jwt/LoginFilter.java
+++ b/src/main/java/fitloop/member/jwt/LoginFilter.java
@@ -86,7 +86,12 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String refreshToken = jwtUtil.createJwt("refresh", username, role, 86400000L);
 
         // AccessToken Redis 저장 (TTL 10분)
-        redisTemplate.opsForValue().set("ACCESS:" + accessToken, username, 10, TimeUnit.MINUTES);
+        String redisKey = "auth:access:" + username;
+        String redisValue = objectMapper.writeValueAsString(Map.of(
+                "role", role,
+                "token", accessToken
+        ));
+        redisTemplate.opsForValue().set(redisKey, redisValue, 10, TimeUnit.MINUTES);
 
         // RefreshToken DB 저장
         saveRefreshToken(username, refreshToken, 86400000L);


### PR DESCRIPTION
## 📝 Description
- Redis에 저장되는 AccessToken 구조를 로그인 시와 재발급 시 일관되게 통일하였습니다.
- 기존 ReissueController에서는 AccessToken을 단순 문자열로 저장하고 있었으나, 로그인 시와 동일하게 JSON 형식 (`{ "role": ..., "token": ... }`)으로 저장하도록 수정하였습니다.

## #️⃣ Issue
- closed #25

## 📷 Screen Shot
- 

## 💬 To Reviewers
- - Redis에 저장되는 Key는 `auth:access:{username}`, Value는 `{"role": ..., "token": ...}` JSON 문자열입니다.
- JWTUtil, RedisTemplate 로직에 대한 일관성 확인 바랍니다.
