### PR TITLE
[FEATURE] Kafka 연동 및 Swagger 설정 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,69 @@ FITLOOP 백엔드는 Spring Boot & Spring Security 기반으로 구축되었으�
 - 식별자와 여는 소괄호 ()사이에는 공백을 삽입하지 않습니다.
   생성자와 메소드의 선언, 호출, 어노테이션 선언 뒤에 쓰이는 소괄호가 이에 해당합니다.
 
+
+<br>
+<br>
+<br>
+
+## 📚 API 명세 (Swagger 기반)
+
+FITLOOP 프로젝트는 Swagger(OpenAPI 3.0)를 활용하여 REST API 명세를 자동화하였으며, SwaggerHub를 통해 팀원들과 API 문서를 공유하고 관리하고 있습니다.
+
+### 🔗 API 문서 보기
+
+- [SwaggerHub 문서 보기](https://app.swaggerhub.com/apis/none-f10-fb1/fitloop-api/1.0.0)
+- 
+- 또는 `fitloop-api.yaml` 파일을 Postman 또는 Swagger Editor에서 불러와 사용 가능
+
+---
+
+### 🧪 테스트 방법
+
+#### Swagger UI (로컬 테스트)
+- 주소: `http://localhost:8080/swagger-ui/index.html`
+- `Try it out` 버튼 클릭 후 실제 API 호출 가능 (JWT access 헤더 필요 시 수동 입력)
+
+#### Postman 테스트
+1. `fitloop-api.yaml` 파일을 다운로드
+2. Postman → `Import` → `File` → YAML 파일 선택
+3. 각 API 요청 실행 (`access` 헤더 등 필요 시 수동 입력)
+
+---
+
+### 📌 주요 API 목록
+
+| Method | Endpoint                          | 설명                   |
+|--------|------------------------------------|------------------------|
+| POST   | `/api/v1/register`                | 회원가입               |
+| POST   | `/api/v1/users/profile`           | 사용자 프로필 등록     |
+| GET    | `/api/v1/user`                    | 유저 정보 조회         |
+| POST   | `/api/v1/products/register`       | 상품 등록              |
+| GET    | `/api/v1/products/{id}`           | 상품 상세 조회         |
+| GET    | `/api/v1/products/recent`         | 최근 상품 목록 조회    |
+| POST   | `/api/v1/cart/add`                | 장바구니 담기          |
+| GET    | `/api/v1/cart`                    | 장바구니 조회          |
+| DELETE | `/api/v1/cart/remove`             | 장바구니 항목 삭제     |
+| DELETE | `/api/v1/cart/clear`              | 장바구니 전체 비우기   |
+| POST   | `/api/v1/reissue`                 | JWT 토큰 재발급        |
+| GET    | `/api/v1/auth/{provider}`         | 소셜 로그인 (Google 등)|
+| GET    | `/health-check`                   | 서버 상태 확인         |
+
+---
+
+### 🧾 요청 예시
+
+#### 회원가입
+```json
+{
+  "username": "testuser",
+  "password": "P@ssw0rd!",
+  "name": "홍길동",
+  "birthday": "1995-05-15",
+  "email": "test@example.com"
+} 
+```
+
 <br>
 <br>
 <br>

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
+	//스웨거
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/fitloop/config/SecurityConfig.java
+++ b/src/main/java/fitloop/config/SecurityConfig.java
@@ -99,9 +99,10 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/v1/google", "/api/v1/login", "/api/v1/register",
+                                "/api/v1/google", "/api/v1/login", "/api/v1/register", "/api/v1/kafka/**",
                                 "/api/v1/reissue", "/api/v1/login/oauth2/code/google",
-                                "/api/v1/oauth2/authorization/google", "/api/v1/auth/**", "/api/v1/products/recent"
+                                "/api/v1/oauth2/authorization/google", "/api/v1/auth/**", "/api/v1/products/recent",
+                                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/products/*").permitAll()
                         .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile").authenticated()

--- a/src/main/java/fitloop/kafka/KafkaConsumer.java
+++ b/src/main/java/fitloop/kafka/KafkaConsumer.java
@@ -1,0 +1,18 @@
+package fitloop.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaConsumer {
+
+    @KafkaListener(topics = "test", groupId = "test-group")
+    public void consume(String message) {
+        System.out.println("구매가 완료되었습니다: " + message);
+    }
+
+    @KafkaListener(topics = "test", groupId = "admin-group")
+    public void consumeAsAdmin(String message) {
+        System.out.println("관리자 확인: " + message);
+    }
+}

--- a/src/main/java/fitloop/kafka/KafkaTestController.java
+++ b/src/main/java/fitloop/kafka/KafkaTestController.java
@@ -1,0 +1,21 @@
+package fitloop.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/kafka")
+public class KafkaTestController {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @PostMapping("/buy")
+    public ResponseEntity<String> buyProduct(@RequestParam String username) {
+        String message = username + "님이 상품을 구매했습니다";
+        kafkaTemplate.send("test", message);
+        return ResponseEntity.ok("전송 완료: " + message);
+    }
+}


### PR DESCRIPTION
## 📝 Description
- Kafka Producer 및 Consumer 로직 구현
- 메시지 발행/구독을 위한 기본 구조 구성 (`KafkaProducer`, `KafkaConsumer`)
- Swagger 문서 공개 설정 추가
- README.md에 SwaggerHub 및 API 테스트 관련 문서 추가
- build.gradle에 Kafka 의존성 추가

## #️⃣ Issue
- closed #34

## 📷 Screen Shot
- ![빌드 사진](https://github.com/user-attachments/assets/5facc803-230e-464e-bfde-45366fc500d8)

## 💬 To Reviewers
- Kafka 설정은 로컬 환경 기준으로 구성되어 있습니다.
