### PR TITLE
[HOTFIX] Refresh 토큰 만료일자 타입 LocalDateTime으로 통일

### DIFF
--- a/src/main/java/fitloop/member/controller/ReissueController.java
+++ b/src/main/java/fitloop/member/controller/ReissueController.java
@@ -1,18 +1,15 @@
 package fitloop.member.controller;
 
 import fitloop.member.service.UserService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@ResponseBody
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class ReissueController {
@@ -21,17 +18,6 @@ public class ReissueController {
 
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = null;
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("refresh".equals(cookie.getName())) {
-                    refreshToken = cookie.getValue();
-                    break;
-                }
-            }
-        }
-
-        return userService.reissueTokens(refreshToken, response);
+        return userService.reissueTokens(request, response);
     }
 }

--- a/src/main/java/fitloop/member/entity/RefreshEntity.java
+++ b/src/main/java/fitloop/member/entity/RefreshEntity.java
@@ -32,11 +32,11 @@ public class RefreshEntity {
     @Column(nullable = false)
     private LocalDateTime lastReissuedAt;
 
-    public static RefreshEntity createRenewed(String username, String refresh, LocalDateTime expiration, LocalDateTime originalFirstIssuedAt) {
+    public static RefreshEntity createRenewed(String username, String refresh, LocalDateTime originalExpiration, LocalDateTime originalFirstIssuedAt) {
         return RefreshEntity.builder()
                 .username(username)
                 .refresh(refresh)
-                .expiration(expiration)
+                .expiration(originalExpiration)
                 .firstIssuedAt(originalFirstIssuedAt)
                 .lastReissuedAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/fitloop/member/entity/RefreshEntity.java
+++ b/src/main/java/fitloop/member/entity/RefreshEntity.java
@@ -24,7 +24,7 @@ public class RefreshEntity {
     private String refresh;
 
     @Column(nullable = false)
-    private String expiration;  // 실제로는 LocalDateTime 추천, 현재 구조 유지
+    private LocalDateTime expiration;
 
     @Column(nullable = false)
     private LocalDateTime firstIssuedAt;
@@ -32,7 +32,7 @@ public class RefreshEntity {
     @Column(nullable = false)
     private LocalDateTime lastReissuedAt;
 
-    public static RefreshEntity createRenewed(String username, String refresh, String expiration, LocalDateTime originalFirstIssuedAt) {
+    public static RefreshEntity createRenewed(String username, String refresh, LocalDateTime expiration, LocalDateTime originalFirstIssuedAt) {
         return RefreshEntity.builder()
                 .username(username)
                 .refresh(refresh)

--- a/src/main/java/fitloop/member/service/UserService.java
+++ b/src/main/java/fitloop/member/service/UserService.java
@@ -154,7 +154,7 @@ public class UserService {
         RefreshEntity entity = RefreshEntity.builder()
                 .username(username)
                 .refresh(refreshToken)
-                .expiration(expiration.toString())
+                .expiration(expiration)
                 .firstIssuedAt(now)
                 .lastReissuedAt(now)
                 .build();
@@ -168,7 +168,7 @@ public class UserService {
         refreshRepository.save(RefreshEntity.createRenewed(
                 username,
                 newToken,
-                new Date(System.currentTimeMillis() + 86_400_000L).toString(),
+                LocalDateTime.now().plusDays(1),
                 firstIssuedAt != null ? firstIssuedAt : LocalDateTime.now()
         ));
     }

--- a/src/main/java/fitloop/member/service/UserService.java
+++ b/src/main/java/fitloop/member/service/UserService.java
@@ -12,6 +12,7 @@ import fitloop.member.repository.RefreshRepository;
 import fitloop.member.repository.UserRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +79,8 @@ public class UserService {
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "프로필 작성 성공"));
     }
 
-    public ResponseEntity<?> reissueTokens(String refreshToken, HttpServletResponse response) {
+    public ResponseEntity<?> reissueTokens(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractCookie(request, "refresh");
         if (refreshToken == null) {
             return ResponseEntity.badRequest().body("리프레시 토큰이 존재하지 않습니다");
         }
@@ -104,7 +105,7 @@ public class UserService {
 
         if (firstIssuedAt != null) {
             Duration duration = Duration.between(firstIssuedAt, LocalDateTime.now());
-            if (duration.toMillis() > 1_209_600_000L) { // 14일
+            if (duration.toMillis() > 1_209_600_000L) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body("리프레시 토큰 발급 유효기간(14일)을 초과했습니다.");
             }
@@ -117,14 +118,13 @@ public class UserService {
         String newRefresh = createRefreshToken(username, role);
 
         saveAccessTokenToRedis(username, role, newAccess);
-        renewRefreshToken(refreshToken, newRefresh, username, firstIssuedAt);
+        renewRefreshToken(refreshToken, newRefresh, username);
 
         response.addCookie(createAccessCookie(newAccess));
         response.addCookie(createRefreshCookie(newRefresh));
 
         return ResponseEntity.ok().build();
     }
-
 
     public String createAccessToken(String username, String role) {
         return jwtUtil.createJwt("access", username, role, 600_000L); // 10분
@@ -149,7 +149,7 @@ public class UserService {
 
     public void saveNewRefreshToken(String username, String refreshToken) {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime expiration = now.plusDays(1); // 24시간
+        LocalDateTime expiration = now.plusDays(1);
 
         RefreshEntity entity = RefreshEntity.builder()
                 .username(username)
@@ -162,14 +162,18 @@ public class UserService {
         refreshRepository.save(entity);
     }
 
-    public void renewRefreshToken(String oldToken, String newToken, String username, LocalDateTime firstIssuedAt) {
+    public void renewRefreshToken(String oldToken, String newToken, String username) {
+        Optional<RefreshEntity> oldEntityOpt = refreshRepository.findByRefresh(oldToken);
+        if (oldEntityOpt.isEmpty()) return;
+
+        RefreshEntity oldEntity = oldEntityOpt.get();
         refreshRepository.deleteByRefresh(oldToken);
 
         refreshRepository.save(RefreshEntity.createRenewed(
                 username,
                 newToken,
-                LocalDateTime.now().plusDays(1),
-                firstIssuedAt != null ? firstIssuedAt : LocalDateTime.now()
+                oldEntity.getExpiration(),
+                oldEntity.getFirstIssuedAt()
         ));
     }
 
@@ -189,5 +193,15 @@ public class UserService {
         cookie.setSecure(false);
         cookie.setPath("/");
         return cookie;
+    }
+
+    private String extractCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals(name)) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## 📝 Description
- Refresh 토큰 만료일자 타입을 String에서 LocalDateTime으로 변경하여 날짜 저장 포맷을 일관화
- 기존 Date.toString() 기반 저장 로직 제거

## #️⃣ Issue
- closed #39

## 💬 To Reviewers
- 향후 토큰 만료 관련 검증 로직에도 LocalDateTime 기준 비교 방식이 적용되는지 검토해주세요.
