### PR TITLE
[FEATURE] 계좌번호 등록 api 추가

### DIFF
--- a/src/main/java/fitloop/config/SecurityConfig.java
+++ b/src/main/java/fitloop/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
                                 "/api/v1/search"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/products/*").permitAll()
-                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile").authenticated()
+                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile", "api/v1/profile/account").authenticated()
                         .requestMatchers("/api/v1/user").hasAuthority("MEMBER")
                         .requestMatchers("/api/v1/admin").hasRole("ADMIN")
                         .anyRequest().authenticated()
@@ -168,7 +168,7 @@ public class SecurityConfig {
                 "/api/v1/reissue", "/api/v1/auth/", "/api/v1/user",
                 "/api/v1/admin", "/api/v1/users/profile", "/api/v1/products/register",
                 "/api/v1/upload", "/api/v1/products", "/api/v1/batch", "/api/v1/cart",
-                "/api/v1/search"
+                "/api/v1/search", "api/v1/profile/account"
                 ).stream().anyMatch(requestURI::startsWith);
     }
 }

--- a/src/main/java/fitloop/config/SecurityConfig.java
+++ b/src/main/java/fitloop/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
                                 "/api/v1/search"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/products/*").permitAll()
-                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile", "api/v1/profile/account").authenticated()
+                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile", "/api/v1/profile/account").authenticated()
                         .requestMatchers("/api/v1/user").hasAuthority("MEMBER")
                         .requestMatchers("/api/v1/admin").hasRole("ADMIN")
                         .anyRequest().authenticated()
@@ -168,7 +168,7 @@ public class SecurityConfig {
                 "/api/v1/reissue", "/api/v1/auth/", "/api/v1/user",
                 "/api/v1/admin", "/api/v1/users/profile", "/api/v1/products/register",
                 "/api/v1/upload", "/api/v1/products", "/api/v1/batch", "/api/v1/cart",
-                "/api/v1/search", "api/v1/profile/account"
+                "/api/v1/search", "/api/v1/profile/account"
                 ).stream().anyMatch(requestURI::startsWith);
     }
 }

--- a/src/main/java/fitloop/member/controller/ProfileController.java
+++ b/src/main/java/fitloop/member/controller/ProfileController.java
@@ -1,0 +1,24 @@
+package fitloop.member.controller;
+
+import fitloop.member.dto.request.AccountNumberRequest;
+import fitloop.member.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/profile")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @PostMapping("/account")
+    public ResponseEntity<?> saveAccountNumber(
+            @RequestBody AccountNumberRequest request,
+            @AuthenticationPrincipal Object principal
+    ) {
+        return profileService.saveAccountNumber(request, principal);
+    }
+}

--- a/src/main/java/fitloop/member/dto/request/AccountNumberRequest.java
+++ b/src/main/java/fitloop/member/dto/request/AccountNumberRequest.java
@@ -1,0 +1,12 @@
+package fitloop.member.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AccountNumberRequest {
+    private String bankName;
+    private String accountNumber;
+    private String depositor;
+}

--- a/src/main/java/fitloop/member/entity/ProfileEntity.java
+++ b/src/main/java/fitloop/member/entity/ProfileEntity.java
@@ -54,6 +54,9 @@ public class ProfileEntity {
     @Column(length = 255)
     private String accountNumber;
 
+    @Column(length = 255)
+    private String depositor;
+
     @Column(nullable = false)
     private Double ecoPoints;
 

--- a/src/main/java/fitloop/member/service/ProfileService.java
+++ b/src/main/java/fitloop/member/service/ProfileService.java
@@ -1,0 +1,46 @@
+package fitloop.member.service;
+
+import fitloop.member.dto.request.AccountNumberRequest;
+import fitloop.member.dto.request.CustomUserDetails;
+import fitloop.member.entity.ProfileEntity;
+import fitloop.member.repository.ProfileRepository;
+import fitloop.member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
+
+    public ResponseEntity<?> saveAccountNumber(AccountNumberRequest request, Object principal) {
+        if (!(principal instanceof CustomUserDetails userDetails)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "인증이 필요합니다."));
+        }
+
+        Optional<ProfileEntity> profileOpt = userRepository.findByUsername(userDetails.getUsername())
+                .flatMap(profileRepository::findByUserId);
+
+        if (profileOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", "사용자를 찾을 수 없습니다."));
+        }
+
+        ProfileEntity profile = profileOpt.get();
+
+        profile.setBankName(request.getBankName());
+        profile.setAccountNumber(request.getAccountNumber());
+        profile.setDepositor(request.getDepositor());
+
+        profileRepository.save(profile);
+
+        return ResponseEntity.ok(Map.of("message", "계좌번호가 저장되었습니다."));
+    }
+}


### PR DESCRIPTION
## 📝 Description
- 프로필에 계좌번호, 은행명, 예금주를 저장하는 계좌번호 등록 API 구현
- ProfileEntity에 depositor(예금주) 컬럼 추가
- AccountNumberRequest DTO 생성
- ProfileController에 계좌번호 등록 엔드포인트 추가
- ProfileService에서 사용자 프로필 조회 및 계좌정보 저장 로직 구현
- SecurityConfig에 API 접근 권한 설정

## #️⃣ Issue
- closed #49

## 📷 Screen Shot
- <img width="530" height="779" alt="계좌번호 저장" src="https://github.com/user-attachments/assets/f97b0276-dede-4713-b0c0-6085859a31c8" />


## 💬 To Reviewers
- 사용자 인증이 필요한 API입니다. 기존 프로필 작성이 되어 있어야 정상적으로 계좌번호를 등록할 수 있습니다.
- 더미데이터 변경이 필요 할 것 같습니다.
