### PR TITLE
[FEATURE] 회원 탈퇴 및 결제 도메인 통합 구현

### DIFF
--- a/src/main/java/fitloop/config/SecurityConfig.java
+++ b/src/main/java/fitloop/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
                                 "/api/v1/search"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/products/*").permitAll()
-                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile", "/api/v1/profile/account").authenticated()
+                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile", "/api/v1/profile/account","/api/v1/users").authenticated()
                         .requestMatchers("/api/v1/user").hasAuthority("MEMBER")
                         .requestMatchers("/api/v1/admin").hasRole("ADMIN")
                         .anyRequest().authenticated()
@@ -168,7 +168,7 @@ public class SecurityConfig {
                 "/api/v1/reissue", "/api/v1/auth/", "/api/v1/user",
                 "/api/v1/admin", "/api/v1/users/profile", "/api/v1/products/register",
                 "/api/v1/upload", "/api/v1/products", "/api/v1/batch", "/api/v1/cart",
-                "/api/v1/search", "/api/v1/profile/account"
+                "/api/v1/search", "/api/v1/profile/account","/api/v1/users"
                 ).stream().anyMatch(requestURI::startsWith);
     }
 }

--- a/src/main/java/fitloop/config/SecurityConfig.java
+++ b/src/main/java/fitloop/config/SecurityConfig.java
@@ -106,7 +106,16 @@ public class SecurityConfig {
                                 "/api/v1/search"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/products/*").permitAll()
-                        .requestMatchers("/api/v1/products/register", "/api/v1/upload", "/api/v1/users/profile", "/api/v1/profile/account","/api/v1/users").authenticated()
+                        .requestMatchers(
+                                "/api/v1/products/register",
+                                "/api/v1/upload",
+                                "/api/v1/users/profile",
+                                "/api/v1/profile/account",
+                                "/api/v1/users",
+                                "/api/v1/orders/**",
+                                "/api/v1/wallets/**",
+                                "/api/v1/withdrawals/**"
+                        ).authenticated()
                         .requestMatchers("/api/v1/user").hasAuthority("MEMBER")
                         .requestMatchers("/api/v1/admin").hasRole("ADMIN")
                         .anyRequest().authenticated()
@@ -168,7 +177,8 @@ public class SecurityConfig {
                 "/api/v1/reissue", "/api/v1/auth/", "/api/v1/user",
                 "/api/v1/admin", "/api/v1/users/profile", "/api/v1/products/register",
                 "/api/v1/upload", "/api/v1/products", "/api/v1/batch", "/api/v1/cart",
-                "/api/v1/search", "/api/v1/profile/account","/api/v1/users"
+                "/api/v1/search", "/api/v1/profile/account","/api/v1/users",
+                "/api/v1/orders", "/api/v1/wallets", "/api/v1/withdrawals"
                 ).stream().anyMatch(requestURI::startsWith);
     }
 }

--- a/src/main/java/fitloop/member/controller/UserController.java
+++ b/src/main/java/fitloop/member/controller/UserController.java
@@ -3,6 +3,7 @@ package fitloop.member.controller;
 import fitloop.member.dto.request.ProfileRequest;
 import fitloop.member.dto.response.ProfileResponse;
 import fitloop.member.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,5 +27,11 @@ public class UserController {
             @AuthenticationPrincipal Object principal,
             @RequestHeader("access") String accessToken) {
         return userService.createProfile(profileRequest, principal, accessToken);
+    }
+
+    @DeleteMapping("/users")
+    public ResponseEntity<?> deleteMyAccount(@AuthenticationPrincipal Object principal,
+                                             HttpServletResponse response) {
+        return userService.deleteAccount(principal, response);
     }
 }

--- a/src/main/java/fitloop/member/repository/ProfileRepository.java
+++ b/src/main/java/fitloop/member/repository/ProfileRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface ProfileRepository extends JpaRepository<ProfileEntity, Long> {
     Optional<ProfileEntity> findByUserId(UserEntity userEntity);
+    void deleteByUserId(UserEntity user);
 }

--- a/src/main/java/fitloop/member/repository/RefreshRepository.java
+++ b/src/main/java/fitloop/member/repository/RefreshRepository.java
@@ -14,4 +14,7 @@ public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
 
     @Transactional
     void deleteByRefresh(String refresh);
+
+    @Transactional
+    void deleteByUsername(String username);
 }

--- a/src/main/java/fitloop/payment/controller/OrderController.java
+++ b/src/main/java/fitloop/payment/controller/OrderController.java
@@ -1,0 +1,47 @@
+package fitloop.payment.controller;
+
+import fitloop.member.auth.VerifiedMember;
+import fitloop.member.auth.MemberIdentity;
+import fitloop.payment.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    // 주문 생성 (buyerId는 로그인 유저 ID로 처리)
+    @PostMapping
+    public ResponseEntity<?> createOrder(
+            @RequestParam Long sellerId,
+            @RequestParam Long productId,
+            @RequestParam Long amount,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return orderService.createOrder(member.id(), sellerId, productId, amount);
+    }
+
+    // 주문 상태 변경 (예: 배송중, 송장번호 업데이트 등)
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<?> updateStatus(
+            @PathVariable Long orderId,
+            @RequestParam String status,
+            @RequestParam(required = false) String trackingNumber,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return orderService.updateStatus(orderId, status, trackingNumber, member.id());
+    }
+
+    // 주문 완료 처리 (구매자가 상품 수령 확정)
+    @PostMapping("/{orderId}/complete")
+    public ResponseEntity<?> completeOrder(
+            @PathVariable Long orderId,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return orderService.completeOrder(orderId, member.id());
+    }
+}

--- a/src/main/java/fitloop/payment/controller/WalletController.java
+++ b/src/main/java/fitloop/payment/controller/WalletController.java
@@ -1,0 +1,42 @@
+package fitloop.payment.controller;
+
+import fitloop.member.auth.VerifiedMember;
+import fitloop.member.auth.MemberIdentity;
+import fitloop.payment.service.WalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/wallets")
+public class WalletController {
+
+    private final WalletService walletService;
+
+    // 지갑 충전
+    @PostMapping("/charge")
+    public ResponseEntity<?> charge(
+            @RequestParam Long amount,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return walletService.charge(member.id(), amount);
+    }
+
+    // 지갑 차감
+    @PostMapping("/deduct")
+    public ResponseEntity<?> deduct(
+            @RequestParam Long amount,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return walletService.deduct(member.id(), amount);
+    }
+
+    // 잔액 조회
+    @GetMapping("/balance")
+    public ResponseEntity<?> getBalance(
+            @VerifiedMember MemberIdentity member
+    ) {
+        return walletService.getBalance(member.id());
+    }
+}

--- a/src/main/java/fitloop/payment/controller/WithdrawalController.java
+++ b/src/main/java/fitloop/payment/controller/WithdrawalController.java
@@ -1,0 +1,36 @@
+package fitloop.payment.controller;
+
+import fitloop.member.auth.VerifiedMember;
+import fitloop.member.auth.MemberIdentity;
+import fitloop.payment.service.WithdrawalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/withdrawals")
+public class WithdrawalController {
+
+    private final WithdrawalService withdrawalService;
+
+    // 출금 요청 (sellerId = 로그인 유저 ID)
+    @PostMapping
+    public ResponseEntity<?> requestWithdrawal(
+            @RequestParam Long amount,
+            @RequestParam String bankName,
+            @RequestParam String accountNumber,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return withdrawalService.requestWithdrawal(member.id(), amount, bankName, accountNumber);
+    }
+
+    // 출금 완료 처리 (관리자 권한이거나, 단순히 시뮬레이션용)
+    @PostMapping("/{withdrawalId}/complete")
+    public ResponseEntity<?> completeWithdrawal(
+            @PathVariable Long withdrawalId,
+            @VerifiedMember MemberIdentity member
+    ) {
+        return withdrawalService.completeWithdrawal(withdrawalId, member.id());
+    }
+}

--- a/src/main/java/fitloop/payment/entity/Order.java
+++ b/src/main/java/fitloop/payment/entity/Order.java
@@ -1,0 +1,35 @@
+package fitloop.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "orders")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long buyerId;
+    private Long sellerId;
+    private Long productId;
+    private Long amount;
+
+    private String status;
+    private String trackingNumber;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/fitloop/payment/entity/Wallet.java
+++ b/src/main/java/fitloop/payment/entity/Wallet.java
@@ -1,0 +1,33 @@
+package fitloop.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "wallets")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class Wallet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long balance;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/fitloop/payment/entity/WalletTransaction.java
+++ b/src/main/java/fitloop/payment/entity/WalletTransaction.java
@@ -1,0 +1,50 @@
+package fitloop.payment.entity;
+
+import fitloop.payment.entity.type.TransactionType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "wallet_transactions")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class WalletTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 유저의 거래인지
+    @Column(nullable = false)
+    private Long userId;
+
+    // 구매자 ↔ 판매자 거래의 경우 상대방 ID
+    private Long counterpartyId;
+
+    // 어떤 주문(혹은 충전)과 연결된 것인지
+    private Long orderId;
+
+    // 어떤 상품 거래인지 추적용 (선택)
+    private Long productId;
+
+    // 거래 금액
+    @Column(nullable = false)
+    private Long amount;
+
+    // 거래 타입 (충전, 구매, 판매수익, 출금, 환불 등)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransactionType type;
+
+    // 결제 수단 (KAKAOPAY, WALLET, CARD 등)
+    private String method;
+
+    // 설명 (예: "카카오페이 충전", "에어포스 구매", "출금 완료")
+    private String description;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/fitloop/payment/entity/Withdrawal.java
+++ b/src/main/java/fitloop/payment/entity/Withdrawal.java
@@ -1,0 +1,34 @@
+package fitloop.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "withdrawals")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class Withdrawal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long sellerId;
+    private Long amount;
+
+    private String bankName;
+    private String accountNumber;
+    private String status;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/fitloop/payment/entity/type/TransactionType.java
+++ b/src/main/java/fitloop/payment/entity/type/TransactionType.java
@@ -1,0 +1,12 @@
+package fitloop.payment.entity.type;
+
+public enum TransactionType {
+    CHARGE,        // 충전
+    PURCHASE,      // 구매
+    SALE,          // 판매 수익
+    WITHDRAWAL,    // 출금
+    REFUND,        // 환불
+    FEE,           // 수수료
+    POINT_EARN,    // 포인트 적립
+    POINT_SPEND    // 포인트 사용
+}

--- a/src/main/java/fitloop/payment/repository/OrderRepository.java
+++ b/src/main/java/fitloop/payment/repository/OrderRepository.java
@@ -1,0 +1,12 @@
+package fitloop.payment.repository;
+
+import fitloop.payment.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByBuyerId(Long buyerId);
+
+    List<Order> findBySellerId(Long sellerId);
+}

--- a/src/main/java/fitloop/payment/repository/WalletRepository.java
+++ b/src/main/java/fitloop/payment/repository/WalletRepository.java
@@ -1,0 +1,10 @@
+package fitloop.payment.repository;
+
+import fitloop.payment.entity.Wallet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+    Optional<Wallet> findByUserId(Long userId);
+}

--- a/src/main/java/fitloop/payment/repository/WalletTransactionRepository.java
+++ b/src/main/java/fitloop/payment/repository/WalletTransactionRepository.java
@@ -1,0 +1,20 @@
+package fitloop.payment.repository;
+
+import fitloop.payment.entity.WalletTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WalletTransactionRepository extends JpaRepository<WalletTransaction, Long> {
+
+    // 특정 유저의 거래 내역 조회 (최신순)
+    List<WalletTransaction> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 특정 주문과 관련된 거래 내역 조회
+    List<WalletTransaction> findByOrderId(Long orderId);
+
+    // 특정 상품과 관련된 거래 내역 조회
+    List<WalletTransaction> findByProductId(Long productId);
+}

--- a/src/main/java/fitloop/payment/repository/WithdrawalRepository.java
+++ b/src/main/java/fitloop/payment/repository/WithdrawalRepository.java
@@ -1,0 +1,10 @@
+package fitloop.payment.repository;
+
+import fitloop.payment.entity.Withdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WithdrawalRepository extends JpaRepository<Withdrawal, Long> {
+    List<Withdrawal> findBySellerId(Long sellerId);
+}

--- a/src/main/java/fitloop/payment/service/OrderService.java
+++ b/src/main/java/fitloop/payment/service/OrderService.java
@@ -2,8 +2,11 @@ package fitloop.payment.service;
 
 import fitloop.payment.entity.Order;
 import fitloop.payment.entity.Wallet;
+import fitloop.payment.entity.WalletTransaction;
+import fitloop.payment.entity.type.TransactionType;
 import fitloop.payment.repository.OrderRepository;
 import fitloop.payment.repository.WalletRepository;
+import fitloop.payment.repository.WalletTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,7 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final WalletRepository walletRepository;
+    private final WalletTransactionRepository walletTransactionRepository;
 
     @Transactional
     public ResponseEntity<?> createOrder(Long buyerId, Long sellerId, Long productId, Long amount) {
@@ -35,6 +39,18 @@ public class OrderService {
                 .status("ORDERED")
                 .build();
         orderRepository.save(order);
+
+        WalletTransaction buyerTx = WalletTransaction.builder()
+                .userId(buyerId)
+                .counterpartyId(sellerId)
+                .orderId(order.getId())
+                .productId(productId)
+                .amount(amount)
+                .type(TransactionType.PURCHASE)
+                .method("WALLET")
+                .description("상품 구매 결제")
+                .build();
+        walletTransactionRepository.save(buyerTx);
 
         return ResponseEntity.ok(order);
     }

--- a/src/main/java/fitloop/payment/service/OrderService.java
+++ b/src/main/java/fitloop/payment/service/OrderService.java
@@ -1,0 +1,88 @@
+package fitloop.payment.service;
+
+import fitloop.payment.entity.Order;
+import fitloop.payment.entity.Wallet;
+import fitloop.payment.repository.OrderRepository;
+import fitloop.payment.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final WalletRepository walletRepository;
+
+    @Transactional
+    public ResponseEntity<?> createOrder(Long buyerId, Long sellerId, Long productId, Long amount) {
+        Wallet buyerWallet = walletRepository.findByUserId(buyerId)
+                .orElseThrow(() -> new IllegalArgumentException("지갑을 찾을 수 없습니다."));
+        if (buyerWallet.getBalance() < amount) {
+            return ResponseEntity.badRequest().body("잔액이 부족합니다.");
+        }
+        buyerWallet.setBalance(buyerWallet.getBalance() - amount);
+
+        Order order = Order.builder()
+                .buyerId(buyerId)
+                .sellerId(sellerId)
+                .productId(productId)
+                .amount(amount)
+                .status("ORDERED")
+                .build();
+        orderRepository.save(order);
+
+        return ResponseEntity.ok(order);
+    }
+
+    @Transactional
+    public ResponseEntity<?> updateStatus(Long orderId, String status, String trackingNumber, Long userId) {
+        Optional<Order> opt = orderRepository.findById(orderId);
+        if (opt.isEmpty()) {
+            return ResponseEntity.badRequest().body("주문을 찾을 수 없습니다.");
+        }
+        Order order = opt.get();
+
+        if (!order.getSellerId().equals(userId)) {
+            return ResponseEntity.status(403).body("본인만 주문 상태를 변경할 수 있습니다.");
+        }
+
+        order.setStatus(status);
+        if (trackingNumber != null) {
+            order.setTrackingNumber(trackingNumber);
+        }
+        orderRepository.save(order);
+
+        return ResponseEntity.ok(order);
+    }
+
+    @Transactional
+    public ResponseEntity<?> completeOrder(Long orderId, Long buyerId) {
+        Optional<Order> opt = orderRepository.findById(orderId);
+        if (opt.isEmpty()) {
+            return ResponseEntity.badRequest().body("주문을 찾을 수 없습니다.");
+        }
+        Order order = opt.get();
+
+        if (!order.getBuyerId().equals(buyerId)) {
+            return ResponseEntity.status(403).body("본인만 주문을 완료할 수 있습니다.");
+        }
+
+        order.setStatus("COMPLETED");
+        orderRepository.save(order);
+
+        Wallet sellerWallet = walletRepository.findByUserId(order.getSellerId())
+                .orElseThrow(() -> new IllegalArgumentException("판매자 지갑을 찾을 수 없습니다."));
+        sellerWallet.setBalance(sellerWallet.getBalance() + order.getAmount());
+
+        return ResponseEntity.ok(order);
+    }
+
+    public ResponseEntity<?> getOrdersByBuyer(Long buyerId) {
+        return ResponseEntity.ok(orderRepository.findByBuyerId(buyerId));
+    }
+}

--- a/src/main/java/fitloop/payment/service/PaymentVerificationService.java
+++ b/src/main/java/fitloop/payment/service/PaymentVerificationService.java
@@ -1,0 +1,79 @@
+package fitloop.payment.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class PaymentVerificationService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${iamport.api.key}")
+    private String apiKey;
+
+    @Value("${iamport.api.secret}")
+    private String apiSecret;
+
+    @Value("${iamport.base-url}")
+    private String baseUrl;
+
+    @Value("${iamport.api.token-path}")
+    private String tokenPath;
+
+    @Value("${iamport.api.payments-path}")
+    private String paymentsPath;
+
+    public Long verifyPayment(String impUid) throws Exception {
+
+        String tokenUrl = baseUrl + tokenPath;
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String tokenBody = String.format("{\"imp_key\":\"%s\",\"imp_secret\":\"%s\"}", apiKey, apiSecret);
+        HttpEntity<String> tokenRequest = new HttpEntity<>(tokenBody, headers);
+
+        ResponseEntity<String> tokenResponse = restTemplate.postForEntity(tokenUrl, tokenRequest, String.class);
+        log.info("토큰 응답 = {}", tokenResponse.getBody());
+
+        JsonNode tokenJson = objectMapper.readTree(tokenResponse.getBody());
+        String accessToken = tokenJson.path("response").path("access_token").asText();
+
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new IllegalStateException("포트원 AccessToken 발급 실패");
+        }
+
+        String paymentUrl = baseUrl + paymentsPath + "/" + impUid;
+        HttpHeaders paymentHeaders = new HttpHeaders();
+        paymentHeaders.set("Authorization", accessToken);
+
+        HttpEntity<Void> paymentRequest = new HttpEntity<>(paymentHeaders);
+        ResponseEntity<String> paymentResponse = restTemplate.exchange(
+                paymentUrl, HttpMethod.GET, paymentRequest, String.class);
+
+        log.info("결제 조회 응답 = {}", paymentResponse.getBody());
+
+        JsonNode paymentJson = objectMapper.readTree(paymentResponse.getBody());
+        JsonNode response = paymentJson.path("response");
+
+        if (response.isMissingNode()) {
+            throw new IllegalArgumentException("결제 검증 실패: response가 비어있음");
+        }
+
+        String status = response.path("status").asText();
+        if (!"paid".equals(status)) {
+            throw new IllegalArgumentException("결제 검증 실패: 결제 상태 = " + status);
+        }
+
+        long amount = response.path("amount").asLong();
+        log.info("결제 검증 성공: impUid = {}, 금액 = {}", impUid, amount);
+
+        return amount;
+    }
+}

--- a/src/main/java/fitloop/payment/service/WalletService.java
+++ b/src/main/java/fitloop/payment/service/WalletService.java
@@ -1,7 +1,10 @@
 package fitloop.payment.service;
 
 import fitloop.payment.entity.Wallet;
+import fitloop.payment.entity.WalletTransaction;
+import fitloop.payment.entity.type.TransactionType;
 import fitloop.payment.repository.WalletRepository;
+import fitloop.payment.repository.WalletTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WalletService {
 
     private final WalletRepository walletRepository;
+    private final WalletTransactionRepository walletTransactionRepository;
 
     @Transactional
     public Wallet charge(Long userId, Long amount) {
@@ -20,6 +24,16 @@ public class WalletService {
                         .balance(0L)
                         .build()));
         wallet.setBalance(wallet.getBalance() + amount);
+
+        WalletTransaction transaction = WalletTransaction.builder()
+                .userId(userId)
+                .amount(amount)
+                .type(TransactionType.CHARGE)
+                .method("KAKAOPAY") // 또는 외부 결제 수단
+                .description("카카오페이 충전")
+                .build();
+        walletTransactionRepository.save(transaction);
+
         return wallet;
     }
 

--- a/src/main/java/fitloop/payment/service/WalletService.java
+++ b/src/main/java/fitloop/payment/service/WalletService.java
@@ -1,0 +1,45 @@
+package fitloop.payment.service;
+
+import fitloop.payment.entity.Wallet;
+import fitloop.payment.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WalletService {
+
+    private final WalletRepository walletRepository;
+
+    @Transactional
+    public Wallet charge(Long userId, Long amount) {
+        Wallet wallet = walletRepository.findByUserId(userId)
+                .orElseGet(() -> walletRepository.save(Wallet.builder()
+                        .userId(userId)
+                        .balance(0L)
+                        .build()));
+        wallet.setBalance(wallet.getBalance() + amount);
+        return wallet;
+    }
+
+    @Transactional
+    public Wallet deduct(Long userId, Long amount) {
+        Wallet wallet = walletRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("지갑을 찾을 수 없습니다."));
+
+        if (wallet.getBalance() < amount) {
+            throw new IllegalArgumentException("잔액이 부족합니다.");
+        }
+
+        wallet.setBalance(wallet.getBalance() - amount);
+        return wallet;
+    }
+
+    @Transactional(readOnly = true)
+    public Long getBalance(Long userId) {
+        Wallet wallet = walletRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("지갑을 찾을 수 없습니다."));
+        return wallet.getBalance();
+    }
+}

--- a/src/main/java/fitloop/payment/service/WithdrawalService.java
+++ b/src/main/java/fitloop/payment/service/WithdrawalService.java
@@ -1,8 +1,11 @@
 package fitloop.payment.service;
 
 import fitloop.payment.entity.Wallet;
+import fitloop.payment.entity.WalletTransaction;
 import fitloop.payment.entity.Withdrawal;
+import fitloop.payment.entity.type.TransactionType;
 import fitloop.payment.repository.WalletRepository;
+import fitloop.payment.repository.WalletTransactionRepository;
 import fitloop.payment.repository.WithdrawalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,7 @@ public class WithdrawalService {
 
     private final WithdrawalRepository withdrawalRepository;
     private final WalletRepository walletRepository;
+    private final WalletTransactionRepository walletTransactionRepository;
 
     @Transactional
     public ResponseEntity<?> requestWithdrawal(Long sellerId, Long amount, String bankName, String accountNumber) {
@@ -34,6 +38,15 @@ public class WithdrawalService {
                 .status("REQUESTED")
                 .build();
         withdrawalRepository.save(withdrawal);
+
+        WalletTransaction withdrawalTx = WalletTransaction.builder()
+                .userId(sellerId)
+                .amount(amount)
+                .type(TransactionType.WITHDRAWAL)
+                .method("BANK_TRANSFER")
+                .description("출금 요청")
+                .build();
+        walletTransactionRepository.save(withdrawalTx);
 
         return ResponseEntity.ok(withdrawal);
     }

--- a/src/main/java/fitloop/payment/service/WithdrawalService.java
+++ b/src/main/java/fitloop/payment/service/WithdrawalService.java
@@ -1,0 +1,59 @@
+package fitloop.payment.service;
+
+import fitloop.payment.entity.Wallet;
+import fitloop.payment.entity.Withdrawal;
+import fitloop.payment.repository.WalletRepository;
+import fitloop.payment.repository.WithdrawalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawalService {
+
+    private final WithdrawalRepository withdrawalRepository;
+    private final WalletRepository walletRepository;
+
+    @Transactional
+    public ResponseEntity<?> requestWithdrawal(Long sellerId, Long amount, String bankName, String accountNumber) {
+        Wallet wallet = walletRepository.findByUserId(sellerId)
+                .orElseThrow(() -> new IllegalArgumentException("지갑을 찾을 수 없습니다."));
+
+        if (wallet.getBalance() < amount) {
+            return ResponseEntity.badRequest().body("잔액이 부족합니다.");
+        }
+        wallet.setBalance(wallet.getBalance() - amount);
+
+        Withdrawal withdrawal = Withdrawal.builder()
+                .sellerId(sellerId)
+                .amount(amount)
+                .bankName(bankName)
+                .accountNumber(accountNumber)
+                .status("REQUESTED")
+                .build();
+        withdrawalRepository.save(withdrawal);
+
+        return ResponseEntity.ok(withdrawal);
+    }
+
+    @Transactional
+    public ResponseEntity<?> completeWithdrawal(Long withdrawalId, Long sellerId) {
+        Withdrawal withdrawal = withdrawalRepository.findById(withdrawalId)
+                .orElseThrow(() -> new IllegalArgumentException("출금 요청을 찾을 수 없습니다."));
+
+        if (!withdrawal.getSellerId().equals(sellerId)) {
+            return ResponseEntity.status(403).body("본인 출금 요청만 완료할 수 있습니다.");
+        }
+
+        withdrawal.setStatus("COMPLETED");
+        withdrawalRepository.save(withdrawal);
+
+        return ResponseEntity.ok(withdrawal);
+    }
+
+    public ResponseEntity<?> getWithdrawHistory(Long sellerId) {
+        return ResponseEntity.ok(withdrawalRepository.findBySellerId(sellerId));
+    }
+}

--- a/src/main/java/fitloop/product/repository/ProductCategoryRelationRepository.java
+++ b/src/main/java/fitloop/product/repository/ProductCategoryRelationRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface ProductCategoryRelationRepository extends JpaRepository<ProductCategoryRelationEntity, Long> {
     Optional<ProductCategoryRelationEntity> findByProductEntity(ProductEntity product);
+    void deleteAllByProductEntity(ProductEntity product);
 }

--- a/src/main/java/fitloop/product/repository/ProductImageRepository.java
+++ b/src/main/java/fitloop/product/repository/ProductImageRepository.java
@@ -12,4 +12,5 @@ public interface ProductImageRepository extends JpaRepository<ProductImageEntity
     List<ProductImageEntity> findByProductEntityIdIn(List<Long> productIds);
     List<ProductImageEntity> findAllByProductEntity(ProductEntity product);
     List<ProductImageEntity> findByProductEntityId(Long productId);
+    void deleteAllByProductEntity(ProductEntity product);
 }

--- a/src/main/java/fitloop/product/repository/ProductRepository.java
+++ b/src/main/java/fitloop/product/repository/ProductRepository.java
@@ -1,11 +1,13 @@
 package fitloop.product.repository;
 
+import fitloop.member.entity.UserEntity;
 import fitloop.product.entity.ProductEntity;
 
 import fitloop.product.entity.category.BottomCategory;
 import fitloop.product.entity.category.MiddleCategory;
 import fitloop.product.entity.category.TopCategory;
 import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -68,4 +70,5 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
       )
 """)
     List<ProductEntity> searchByQuery(@Param("query") String query);
+    List<ProductEntity> findAllByUserEntity(UserEntity user);
 }

--- a/src/main/java/fitloop/product/repository/ProductTagRepository.java
+++ b/src/main/java/fitloop/product/repository/ProductTagRepository.java
@@ -14,4 +14,6 @@ public interface ProductTagRepository extends JpaRepository<ProductTagEntity, Lo
     List<ProductTagEntity> findByProductEntityIdIn(List<Long> productIds);
     List<ProductTagEntity> findAllByProductEntity(ProductEntity product);
     List<ProductTagEntity> findByProductEntityId(Long productId);
+
+    void deleteAllByProductEntity(ProductEntity product);
 }

--- a/src/main/java/fitloop/stats/dto/StatsOverviewDto.java
+++ b/src/main/java/fitloop/stats/dto/StatsOverviewDto.java
@@ -1,0 +1,41 @@
+package fitloop.stats.dto;
+
+import fitloop.stats.entity.UserStats;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record StatsOverviewDto(
+        Long memberId,
+        long purchaseCount,
+        long salesCount,
+        long reviewCount,
+        long couponCount,
+        long pointBalance,
+        LocalDateTime updatedAt
+) {
+    public static StatsOverviewDto from(UserStats s) {
+        return StatsOverviewDto.builder()
+                .memberId(s.getMemberId())
+                .purchaseCount(s.getPurchaseCount())
+                .salesCount(s.getSalesCount())
+                .reviewCount(s.getReviewCount())
+                .couponCount(s.getCouponAvailableCount())
+                .pointBalance(s.getPointBalance())
+                .updatedAt(s.getUpdatedAt())
+                .build();
+    }
+
+    public static StatsOverviewDto zero(Long memberId) {
+        return StatsOverviewDto.builder()
+                .memberId(memberId)
+                .purchaseCount(0)
+                .salesCount(0)
+                .reviewCount(0)
+                .couponCount(0)
+                .pointBalance(0)
+                .updatedAt(null)
+                .build();
+    }
+}

--- a/src/main/java/fitloop/stats/entity/UserStats.java
+++ b/src/main/java/fitloop/stats/entity/UserStats.java
@@ -1,0 +1,74 @@
+package fitloop.stats.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "user_stats")
+public class UserStats {
+
+    @Id
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "purchase_count", nullable = false)
+    private long purchaseCount;
+
+    @Column(name = "sales_count", nullable = false)
+    private long salesCount;
+
+    @Column(name = "review_count", nullable = false)
+    private long reviewCount;
+
+    @Column(name = "coupon_available_count", nullable = false)
+    private long couponAvailableCount;
+
+    @Column(name = "point_balance", nullable = false)
+    private long pointBalance;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void incPurchase() { this.purchaseCount++; }
+    public void incSales()    { this.salesCount++;   }
+    public void incReview()   { this.reviewCount++;  }
+
+    public void addCoupons(long delta) {
+        this.couponAvailableCount += delta;
+        if (this.couponAvailableCount < 0) this.couponAvailableCount = 0;
+    }
+
+    public void addPoints(long delta) {
+        this.pointBalance += delta;
+        if (this.pointBalance < 0) this.pointBalance = 0;
+    }
+
+    public static UserStats zeroOf(Long memberId) {
+        return UserStats.builder()
+                .memberId(memberId)
+                .purchaseCount(0)
+                .salesCount(0)
+                .reviewCount(0)
+                .couponAvailableCount(0)
+                .pointBalance(0)
+                .build();
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -326,3 +326,16 @@ INSERT INTO profile (
       (8, '간식 탐험가', 'FEMALE', '20-29', 165.0, 55.0, 'https://picsum.photos/id/305/350/450', '서울특별시 마포구', '04000', '국민은행', '123-45-678901', 0.0, NOW(), NOW()),
       (9, '새벽 감성러', 'FEMALE', '20-29', 165.0, 55.0, 'https://picsum.photos/id/342/350/450', '서울특별시 마포구', '04000', '국민은행', '123-45-678901', 0.0, NOW(), NOW()),
       (10, '넷플릭서', 'FEMALE', '20-29', 165.0, 55.0, 'https://picsum.photos/id/365/350/450', '서울특별시 마포구', '04000', '국민은행', '123-45-678901', 0.0, NOW(), NOW());
+
+INSERT INTO wallets (user_id, balance, created_at, updated_at)
+VALUES
+    (1, 15000, NOW(), NOW()),
+    (2, 82000, NOW(), NOW()),
+    (3, 45000, NOW(), NOW()),
+    (4, 270000, NOW(), NOW()),
+    (5, 9900, NOW(), NOW()),
+    (6, 130000, NOW(), NOW()),
+    (7, 57000, NOW(), NOW()),
+    (8, 220000, NOW(), NOW()),
+    (9, 34500, NOW(), NOW()),
+    (10, 76000, NOW(), NOW());


### PR DESCRIPTION
## 📝 Description  
- 회원 탈퇴 기능 관련 전체 구현 내역  
  - 회원 탈퇴 API 엔드포인트 및 로직 추가  
  - 관련 Repository 메서드(`deleteAllByProductEntity`, `findAllByUserEntity`) 구현  
  - `SecurityConfig`에서 `/api/v1/users` 엔드포인트 접근 제어 추가  
  - `UserService` 내 `deleteAccount()` 로직 구현  

- 결제(Payment) 도메인 추가  
  - `Order`, `Wallet`, `Withdrawal` 엔티티 및 Repository, Service 계층 추가  
  - `WalletController`, `OrderController`, `WithdrawalController` 구현  
  - 지갑 충전/차감/출금 API 및 트랜잭션 기록 기능 추가  
  - `WalletTransaction` 엔티티 및 `TransactionType` enum 생성  
  - 주문 및 출금 시 트랜잭션 이력 반영  
  - 회원가입 시 지갑 자동 생성 로직 추가  
  - 초기 `wallets` 데이터 insert 구문 추가  

- 통계(Stats) 기능 추가  
  - `UserStats` 엔티티 생성 및 필드 정의  
  - `StatsOverviewDto` 구현 및 변환 메서드 추가  



## #️⃣ Issue  
- #49  



## 📷 Screen Shot  
- (추후 API 테스트 캡처 추가해서 올리겠습니다.)



## 💬 To Reviewers  
- 결제, 지갑, 정산, 트랜잭션 기능이 도메인 단위로 분리되어 있으니 계층 간 참조 및 의존성 부분을 중점적으로 확인 부탁드립니다.  
- 통계 기능(`UserStats`)은 추후 사용자 활동 지표를 위한 확장성을 고려하여 기본 구조만 정의했습니다. 
- ERD를 전체적으로 수정하고 있습니다. 정산보류(에스크로) 설계 추가 및 이력 테이블을 수정하고 있습니다.
- 결제 부분에 있는 쿠폰, 등급 배송비 등의 로직을 수정하고 있습니다.
